### PR TITLE
fixed variable in case else on line 39

### DIFF
--- a/lib/chef/knife/maas_server_list.rb
+++ b/lib/chef/knife/maas_server_list.rb
@@ -36,7 +36,7 @@ class Chef
                            when "6"
                              ui.color("deployed", :green)
                            else
-                             ui.color(state, :green)
+                             ui.color(status, :green)
                            end
                          end
           # NEW = 0


### PR DESCRIPTION
variable was state, but should be status as defined on line 28--state does not exist and results in error if case/else is met